### PR TITLE
WIP: Add GCC2026 scholarship announcement

### DIFF
--- a/content/news/2025-12-gcc2026.md
+++ b/content/news/2025-12-gcc2026.md
@@ -1,0 +1,43 @@
+---
+description: "JXTX + GCC 2026 Scholarships"
+image: ../_images/seo/newsroom.png
+images:
+    - ../_images/gcc2024-banner.png
+title: "JXTX + GCC 2026 Scholarships"
+---
+
+<Date>December 2025</Date>
+
+# JXTX + GCC 2026 Scholarships
+
+<Image alt="JXTX + GCC 2026 Scholarships" image={props.images[0]}></Image>
+
+<figcaption>JXTX + GCC 2026 Scholarships: Supporting travel to the Galaxy Community Conference</figcaption>
+
+The JXTX Foundation and the Galaxy Project announce the 2026 GCC Scholarship program. This program will support outstanding graduate students in genomics and data sciences to attend the [2026 Galaxy Community Conference (GCC2026)](https://galaxyproject.org/events/gcc2026/) in Clermont-Ferrand, France.
+
+GCC2026 will be held June 22-26, 2026, hosted by Université Clermont Auvergne. The conference is the annual gathering of the Galaxy Community with opportunities to hear the latest developments, get training, and meet everyone involved. It brings together researchers, software developers, and trainers to share experiences related to Galaxy.
+
+## JXTX Scholarships:
+
+JXTX scholarships will be awarded in two tiers:
+
+-   The first tier will be awarded to three individuals and will cover conference registration plus transportation to and from the conference (up to €1,000).
+-   The second tier will be awarded to three individuals and will cover conference registration only.
+
+## The JJ Travel Fellowships:
+
+The JJ Travel Fellowships will sponsor up to two graduate students or postdoctoral researchers to attend GCC2026. The fellowship will cover the cost of travel, up to $500 for each recipient. These fellowships honor James Johnson's legacy as a contributor and mentor in the Galaxy community, helping bring new contributors into the Galaxy ecosystem.
+
+For more information on the JJ Travel Fellowships, please see [here](/scholarships/jj-fund).
+
+## Key Dates:
+
+-   Deadline for applications: TBD
+-   Winners announced: TBD
+
+Applicants should be planning to present their work at the conference, either as a talk or as a poster.
+
+## How to Apply:
+
+This year, JXTX Scholarships and JJ Travel Fellowships will use a joint application process. Application details will be announced soon. Sign up for the [GCC2026 mailing list](https://galaxyproject.org/events/gcc2026/) to receive updates.

--- a/content/scholarships/scholarships.md
+++ b/content/scholarships/scholarships.md
@@ -13,6 +13,7 @@ images:
     - _images/scholarships-hero-2025-bog.png
     - _images/scholarships-2025-gbcc.png
     - _images/scholarships-hero-2025-gi.png
+    - ../_images/gcc2024-banner.png
 links:
     - /scholarships/2021-genome-informatics
     - /news/2020-10-jxtx-awardees
@@ -25,6 +26,7 @@ links:
     - /news/2025-2-4-bg
     - /news/2025-2-27-gbcc
     - /news/2025-6-09-gi
+    - /news/2025-12-gcc2026
 slug: "/scholarships"
 title: "Scholarships"
 ---
@@ -34,6 +36,22 @@ title: "Scholarships"
 </Headline>
 
 <Newsroom>
+
+<Grid columns={1}>
+
+<Tile orientation={"HORIZONTAL"} scale={"MEDIUM"} tileLink={props.links[11]}>
+<TileThumbnail alt={"JXTX + GCC 2026 Scholarship"} image={props.images[10]}></TileThumbnail>
+<TileContent>
+<TileHeading>
+JXTX + GCC 2026 Scholarship
+</TileHeading>
+<TileBody>
+The JXTX Foundation and Galaxy Project announce the 2026 GCC Scholarship. Supporting graduate students to attend GCC2026 in Clermont-Ferrand, France.
+</TileBody>
+</TileContent>
+</Tile>
+
+</Grid>
 
 <Grid columns={1}>
 


### PR DESCRIPTION
## Summary
- Add placeholder announcement for JXTX + GCC 2026 scholarships
- Conference: June 22-26, 2026 in Clermont-Ferrand, France
- Includes JJ Travel Fellowships with joint application process

## TODO
- [ ] Create GCC2026 banner image (currently using GCC2024 placeholder)
- [ ] Fill in application deadline and winner announcement dates
- [ ] Finalize application process details