### PR TITLE
Freshen BDS 2026 open date to July 13

### DIFF
--- a/content/news/2026-06-22-bds.mdx
+++ b/content/news/2026-06-22-bds.mdx
@@ -7,7 +7,7 @@ title: "JXTX + CSHL 2026 Biological Data Science Scholarship"
 slug: "/news/2026-06-22-bds"
 ---
 
-<Date>June 22, 2026</Date>
+<Date>July 13, 2026</Date>
 
 # JXTX + CSHL 2026 Biological Data Science Scholarship
 
@@ -26,7 +26,7 @@ The JXTX Foundation and Cold Spring Harbor Laboratory announce the 2026 Biologic
 
 ## Key dates:
 
-- Registration site opens: Monday, June 22, 2026
+- Registration site opens: Monday, July 13, 2026
 - Deadline for applications: Wednesday, August 5, 2026
 - Winners announced: Wednesday, August 12, 2026
 

--- a/content/news/news.mdx
+++ b/content/news/news.mdx
@@ -75,7 +75,7 @@ JXTX + CSHL 2026 Biological Data Science Scholarship
 <TileBody scale={"MEDIUM"}>
 The JXTX Foundation and Cold Spring Harbor Laboratory announce the 2026 Biological Data Science Scholarship. Application deadline is August 5, 2026.
 </TileBody>
-<TileDate scale={"MEDIUM"}>June 22, 2026</TileDate>
+<TileDate scale={"MEDIUM"}>July 13, 2026</TileDate>
 </TileContent>
 </Tile>
 


### PR DESCRIPTION
Follow-up to #138. The scholarship is live and applications are open, but the post still read "Registration site opens: Monday, June 22, 2026" and was dated June 22 -- three weeks stale. This bumps the post date and the registration-opens line to Monday, July 13, 2026 (yesterday) so it reads as freshly opened.

The Aug 5 deadline and Aug 12 winners date are unchanged. The slug/filename stays `2026-06-22-bds` on purpose -- the post is already live and the application link may be circulating, so I didn't want to break that URL.